### PR TITLE
new(suggest): compare commit diff

### DIFF
--- a/pkg/judge/judge.go
+++ b/pkg/judge/judge.go
@@ -2,12 +2,12 @@ package judge
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"strings"
 
 	"github.com/jasondellaluce/synchro/pkg/utils"
-	"github.com/sirupsen/logrus"
 )
 
 type ChangeType int


### PR DESCRIPTION
This PR adds a stronger logic for checking if a PR has been downstreamed.

To check if a commit is already present in the fork, the tool does a first scan picking commits with the same title and then compares their diff with PR's commit diff.
If less than 50% of commits are found in the fork, the PR is picked to be downstreamed.
